### PR TITLE
Add requestId as a variable in the dpd-event context

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ EventResource.prototype.handle = function (ctx, next) {
     }
   };
 
+  domain.requestId = ctx.req.requestId || domain.getHeader('X-Request-Id') || domain.getHeader('x-request-id');
+
   if (ctx.method === "POST" && this.events.post) {
     this.events.post.run(ctx, domain, function(err) {
       ctx.done(err, result);
@@ -60,5 +62,4 @@ EventResource.prototype.handle = function (ctx, next) {
     next();
   }
 
-  
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpd-event",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Deployd module to create custom events at a specified URL.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This will add requestId as a variable for the dpd event resource scope,
it may be as an attribute, or header in the request object with
standard names.

The requestId allows to identify the same client through different
layers in the server for example when passing the same request through
multiple event resources and makes it possible to link the request and
do lookups based on the requestId.

dpd is lowercasing the headers names in the cors module (corser) so, if
is an external call, we get the request id with the normal name as an
attribute in the request due to Express Middleware, but if is an
internal call we get it through the headers.